### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,7 +1,7 @@
 class FurimasController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index,]
-  before_action :move_to_index, only: [:edit, :update]#今後実装, :destroy
-  before_action :set_furima, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
+  before_action :set_furima, only: [:show, :edit, :update, :destroy]
 
   def index
     @furimas = Furima.all.order("created_at DESC")
@@ -31,6 +31,14 @@ class FurimasController < ApplicationController
       redirect_to root_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @furima.destroy
+      redirect_to root_path
+    else
+      render :destroy
     end
   end
 

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,7 +1,7 @@
 class FurimasController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index,]
-  before_action :move_to_index, only: [:edit, :update, :destroy]
   before_action :set_furima, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @furimas = Furima.all.order("created_at DESC")
@@ -47,16 +47,14 @@ class FurimasController < ApplicationController
     params.require(:furima).permit(:item, :image, :text, :category_id, :state_id, :shipping_id, :area_id, :send_day_id, :price).merge(user_id: current_user.id)
   end
 
+  def set_furima
+    @furima = Furima.find(params[:id])
+  end
 
   def move_to_index
-    @furima = Furima.find(params[:id])
     unless @furima.user_id == current_user.id
       redirect_to action: :index
     end
-  end
-
-  def set_furima
-    @furima = Furima.find(params[:id])
   end
 
 end

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,5 +1,5 @@
 class FurimasController < ApplicationController
-  before_action :authenticate_user!, except: [:show, :index,]
+  before_action :authenticate_user!, except: [:show, :index]
   before_action :set_furima, only: [:show, :edit, :update, :destroy]
   before_action :move_to_index, only: [:edit, :update, :destroy]
 
@@ -38,7 +38,7 @@ class FurimasController < ApplicationController
     if @furima.destroy
       redirect_to root_path
     else
-      render :destroy
+      render :show
     end
   end
 

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @furima.user_id %>
     <%= link_to "商品の編集", edit_furima_path(@furima), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", furima_path(@furima.id), method: :delete, class:"item-destroy" %>
     
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   get 'furimas/index'
   root to: "furimas#index"
-  resources :furimas, except: [:destroy]
+  resources :furimas
 
 end


### PR DESCRIPTION
# what
商品削除機能の実装

# why
ログイン状態の出品者のみ、出品した商品情報を削除できるようにするため

# Gyazo一覧
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/47b0da074a5ebe2703756b10ccf9dc4b